### PR TITLE
Process Termination Removal

### DIFF
--- a/src/DbUpdater.EFCore.CLI/ContextUpdater.cs
+++ b/src/DbUpdater.EFCore.CLI/ContextUpdater.cs
@@ -17,12 +17,9 @@ namespace DbUpdater.EFCore.CLI
         /// <returns></returns>
         public static void DeployMigrationFromCLI(this IHost host, string[] args)
         {
-            if (!args.Any())
-            {
-                Environment.Exit(0);
-            }
+            if (!args.Any()) return;
             var parsedOptions = Parser.Default.ParseArguments<MigrationOption>(args);
-            if (parsedOptions.Errors.Any()) Environment.Exit(0);
+            if (parsedOptions.Errors.Any()) Environment.Exit(-1);
 
             try
             {
@@ -32,7 +29,6 @@ namespace DbUpdater.EFCore.CLI
                 {
                     ProjectInformation.ShowHelp();
                     Environment.Exit(0);
-                    return;
                 }
                 Console.WriteLine("Starting migration......");
                 _ = new DbContextMigration(host, parsedOptions.Value);

--- a/src/DbUpdater.EFCore.CLI/DbUpdater.EFCore.CLI.csproj
+++ b/src/DbUpdater.EFCore.CLI/DbUpdater.EFCore.CLI.csproj
@@ -56,4 +56,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="NugetOutput\" />
+  </ItemGroup>
+
 </Project>

--- a/src/DbUpdater.EFCore.CLI/DbUpdater.EFCore.CLI.csproj
+++ b/src/DbUpdater.EFCore.CLI/DbUpdater.EFCore.CLI.csproj
@@ -16,9 +16,9 @@
     <Company>oakinyelure</Company>
     <Title>DbUpdater.EFCore.CLI</Title>
     <ProductName>DbUpdater.EFCore.CLI</ProductName>
-    <AssemblyVersion>1.0.7</AssemblyVersion>
-    <Version>1.0.7</Version>
-    <ProductVersion>1.0.7</ProductVersion>
+    <AssemblyVersion>1.0.8</AssemblyVersion>
+    <Version>1.0.8</Version>
+    <ProductVersion>1.0.8</ProductVersion>
     <PackageTags>efcore;entityframework;ef;continous;integration;efcode_first</PackageTags>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <MinVerTagPrefix>v</MinVerTagPrefix>

--- a/src/DbUpdater.EFCore.CLI/DbUpdater.EFCore.CLI.xml
+++ b/src/DbUpdater.EFCore.CLI/DbUpdater.EFCore.CLI.xml
@@ -118,7 +118,6 @@
             Searches through the assembly to create instances of objects matching the 
             type argument
             </summary>
-            <typeparam name="T"></typeparam>
             <param name="fullContextName"></param>
             <returns>Collection of instances matching the type argument</returns>
         </member>

--- a/src/DbUpdater.EFCore.CLI/RELEASE_NOTES.txt
+++ b/src/DbUpdater.EFCore.CLI/RELEASE_NOTES.txt
@@ -17,6 +17,9 @@ v1.0.5
 - Updated the type lookup class to include method for getting all seedable objects
 
 v1.0.6
-- Added ability to continue executing other script when one script fails to execute
-- Added ability to rollback transactions when a script fails. Successful transactions will be committed
-- Added information to script execution so that the name of the script is visible on the console before execution.
+	- Added ability to continue executing other script when one script fails to execute
+	- Added ability to rollback transactions when a script fails. Successful transactions will be committed
+	- Added information to script execution so that the name of the script is visible on the console before execution.
+v1.0.7
+	- The exit command is causing applications to terminate when ran in non-cli mode. Because the argument list is empty, DbUpdater automatically terminates the application. This is not the desired behavior
+	  V1.0.7 removes the termination.


### PR DESCRIPTION
The exit command is causing applications to terminate when ran in non-CLI mode. Because the argument list is empty, DbUpdater automatically terminates the application. This is not the desired behavior especially when application is not ran through CLI.